### PR TITLE
Add Capistrano dependency

### DIFF
--- a/capistrano-deploy-all.gemspec
+++ b/capistrano-deploy-all.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |spec|
   spec.summary     = "Deploy a service or run a Rake task against all environments"
   spec.description = "Deploy a service or run a Rake task against all environments using Capistrano. The environments are going to be read based on the /config/deploy/*.rb files"
   spec.author      = "Arturo Herrero"
-  spec.email       = "arturo.herrero@mydrivesolutions.com"
+  spec.email       = "arturo.herrero@gmail.com"
   spec.homepage    = "https://github.com/mydrive/capistrano-deploy-all"
   spec.license     = "BSD 2-clause"
 

--- a/capistrano-deploy-all.gemspec
+++ b/capistrano-deploy-all.gemspec
@@ -13,4 +13,6 @@ Gem::Specification.new do |spec|
 
   spec.files       = Dir["{bin,lib}/**/*", "README.md"]
   spec.executables = ["deploy_all", "rake_all"]
+
+  spec.add_dependency "capistrano"
 end


### PR DESCRIPTION
### Description

In order to use this gem we already need Capistrano, so I've added it as a dependency. I've haven't specified any version for Capistrano but we can go with a more fine-grain option.

I've already had an account in RubyGems so I'm going to use my [current user][1] and add [Gavin][2] as owner as well.

[1]: https://rubygems.org/profiles/arturoherrero
[2]: https://rubygems.org/profiles/gavinheavyside

