### PR TITLE
Take environment vars set for the rake task into invoke.rake

### DIFF
--- a/bin/rake_all
+++ b/bin/rake_all
@@ -13,7 +13,7 @@ if deployments.any?
   if response.empty? || response.downcase == "y"
     succeeded = []
     deployments.each do |deployment|
-      if system("#{File.join("bin", "cap")} #{deployment} invoke:rake task=#{task}")
+      if system("#{File.join("bin", "cap")} #{deployment} invoke:rake task='#{task}'")
         succeeded << deployment
       else
         puts "FAILED running against #{deployment}"


### PR DESCRIPTION
We have a need to be able to pass variables into the `rake_all` command. The way we have chosen to do this is by environment variables when choosing the command. So a rake command with variables would look as follows:

```
task_namespace:task_name FIRST_VAR=foo SECOND_VAR=bar
```

This PR requires changes to:
* `rake_all` file to allow the extra parameters to be passed in from the task by enclosing the user's input in single quotes. Without this change, Capistrano will only set up to the first space in the user's input as the details of the task.